### PR TITLE
Fix crash on forgetting a window on a stack

### DIFF
--- a/euclid-wm.c
+++ b/euclid-wm.c
@@ -1026,6 +1026,9 @@ void forget_win (Window id) {
 	while (v != NULL) {
 		s = v->stack;
 		while (s != NULL) {
+			//storing this in case the entry will get free()'d
+			struct stack_item *next_s = s->next;
+
 			if (s->win == w) {
 				if (s == v->stack) {
 					v->stack = s->next;
@@ -1048,7 +1051,8 @@ void forget_win (Window id) {
 				};
 				free(s);
 			};
-			s = s->next;
+
+			s = next_s;
 		};
 		v = v->next;
 	};


### PR DESCRIPTION
Similarly to b2a72cf798357b55d11140a4d5153842381f549e which was caused by `c->next` following `free(c)`, `s->next` is following `free(s)` causing a crash.

A way to reproduce:
 1. Start xterm
 2. Run `gvim -f`
 3. Put GVim's window on a stack
 4. Press Ctrl-Z in xterm
 5. Execute `exit` twice (first time just prints a warning about a stopped job)
 6. euclid-wm should crash here on trying to forget a window that's currently hidden, specifically on dropping a corresponding `struct stack_item`